### PR TITLE
Fix rendering glitches on Mac OS X

### DIFF
--- a/platforms/qt-shared/GLFrame.cpp
+++ b/platforms/qt-shared/GLFrame.cpp
@@ -61,7 +61,7 @@ bool GLFrame::IsRunningRenderThread()
 
 void GLFrame::resizeEvent(QResizeEvent *evt)
 {
-    m_RenderThread.ResizeViewport(evt->size());
+    m_RenderThread.ResizeViewport(evt->size() * devicePixelRatio());
 }
 
 void GLFrame::paintEvent(QPaintEvent *)

--- a/platforms/qt-shared/RenderThread.cpp
+++ b/platforms/qt-shared/RenderThread.cpp
@@ -87,6 +87,8 @@ void RenderThread::run()
                 m_bResizeEvent = false;
             }
 
+            m_pGLFrame->makeCurrent();
+
             RenderFrame();
 
             m_pGLFrame->swapBuffers();


### PR DESCRIPTION
While trying to make a package for [Homebrew](http://brew.sh/), I found some rendering issues on OS X that make it almost not playable.

1. OpenGL viewport size did not take account high DPI found on Retina display.
2. OpenGL context was not ready for `RenderFrame()` after `doneCurrent()` was called in `InitRenderThread()`.

I made a small fix and confirmed it working on Retina MacBook Pro with OS X 10.10.