### PR TITLE
Fix gearystem.ini path.

### DIFF
--- a/platforms/qt-shared/MainWindow.cpp
+++ b/platforms/qt-shared/MainWindow.cpp
@@ -472,7 +472,7 @@ bool MainWindow::event(QEvent *ev)
 
 void MainWindow::LoadSettings()
 {
-    QSettings settings("gearsystem.ini", QSettings::IniFormat);
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/gearsystem.ini", QSettings::IniFormat);
 
     settings.beginGroup("Gearsystem");
     m_iSelectedSlot = settings.value("SavestateSlot", 1).toInt();
@@ -537,7 +537,7 @@ void MainWindow::LoadSettings()
 
 void MainWindow::SaveSettings()
 {
-    QSettings settings("gearsystem.ini", QSettings::IniFormat);
+    QSettings settings(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/gearsystem.ini", QSettings::IniFormat);
 
     settings.beginGroup("Gearsystem");
     settings.setValue("SavestateSlot", m_iSelectedSlot);


### PR DESCRIPTION
The `gearsystem.ini` file is still saving in the current directory instead of in `~/.local/share/Gearystem/`. Looking at the code it looks like this fix was missed from Gearboy. Please make sure I didn't miss anything, thanks!