### PR TITLE
libretro: Add install rules and retro-gtk core descriptor

### DIFF
--- a/platforms/libretro/Makefile
+++ b/platforms/libretro/Makefile
@@ -63,6 +63,10 @@ ifneq (,$(findstring unix,$(platform)))
    LDFLAGS += -lnetwork -lroot
    endif
 
+   prefix := /usr
+   libdir := $(prefix)/lib
+   LIBRETRO_INSTALL_DIR := libretro
+
    # Raspberry Pi
    ifneq (,$(findstring rpi,$(platform)))
       CFLAGS += -fomit-frame-pointer -ffast-math -marm
@@ -191,4 +195,12 @@ endif
 clean:
 	rm -f $(OBJECTS) $(TARGET)
 
-.PHONY: clean
+install:
+	install -D -m 755 $(TARGET) $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET)
+	install -D -m 755 $(TARGET_NAME).libretro $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET_NAME).libretro
+
+uninstall:
+	rm $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET)
+	rm $(DESTDIR)$(libdir)/$(LIBRETRO_INSTALL_DIR)/$(TARGET_NAME).libretro
+
+.PHONY: clean install uninstall

--- a/platforms/libretro/gearsystem.libretro
+++ b/platforms/libretro/gearsystem.libretro
@@ -1,0 +1,14 @@
+[Libretro]
+Type=Emulator
+Version=1.0
+Name=Gearsystem
+Module=gearsystem_libretro.so
+LibretroVersion=1
+Authors=Ignacio Sanchez Gines;
+License=GPL-3.0+;
+
+[Platform:GameGear]
+MimeType=application/x-gamegear-rom;
+
+[Platform:MasterSystem]
+MimeType=application/x-sms-rom;


### PR DESCRIPTION
This is needed for GNOME Games to ship Gearsystem.