### PR TITLE
Added a system to allow configuration of debug keys via the config.ini

### DIFF
--- a/platforms/desktop-shared/application.cpp
+++ b/platforms/desktop-shared/application.cpp
@@ -433,51 +433,38 @@ static void sdl_events_emu(const SDL_Event* event)
 
 static void sdl_shortcuts_gui(const SDL_Event* event)
 {
-    if ((event->type == SDL_KEYDOWN) && (event->key.keysym.mod & KMOD_CTRL))
+    if (event->type == SDL_KEYDOWN)
     {
         int key = event->key.keysym.scancode;
-        
-        switch (key)
+        int mod = event->key.keysym.mod;
+        bool handled = gui_process_input(key, mod);
+
+        if (!handled && (mod & KMOD_CTRL))
         {
-            case SDL_SCANCODE_O:
-                gui_shortcut(gui_ShortcutOpenROM);
-                break;
-            case SDL_SCANCODE_R:
-                gui_shortcut(gui_ShortcutReset);
-                break;
-            case SDL_SCANCODE_P:
-                gui_shortcut(gui_ShortcutPause);
-                break;
-            case SDL_SCANCODE_F:
-                gui_shortcut(gui_ShortcutFFWD);
-                break;
-            case SDL_SCANCODE_L:
-                gui_shortcut(gui_ShortcutLoadState);
-                break;
-            case SDL_SCANCODE_S:
-                gui_shortcut(gui_ShortcutSaveState);
-                break;
-            case SDL_SCANCODE_M:
-                gui_shortcut(gui_ShortcutShowMainMenu);
-                break;
-            case SDL_SCANCODE_F5:
-                gui_shortcut(gui_ShortcutDebugContinue);
-                break;
-            case SDL_SCANCODE_F6:
-                gui_shortcut(gui_ShortcutDebugNextFrame);
-                break;
-            case SDL_SCANCODE_F8:
-                gui_shortcut(gui_ShortcutDebugRuntocursor);
-                break;
-            case SDL_SCANCODE_F9:
-                gui_shortcut(gui_ShortcutDebugBreakpoint);
-                break;
-            case SDL_SCANCODE_F10:
-                gui_shortcut(gui_ShortcutDebugStep);
-                break;
-            case SDL_SCANCODE_BACKSPACE:
-                gui_shortcut(gui_ShortcutDebugGoBack);
-                break;
+            switch (key)
+            {
+                case SDL_SCANCODE_O:
+                    gui_shortcut(gui_ShortcutOpenROM);
+                    break;
+                case SDL_SCANCODE_R:
+                    gui_shortcut(gui_ShortcutReset);
+                    break;
+                case SDL_SCANCODE_P:
+                    gui_shortcut(gui_ShortcutPause);
+                    break;
+                case SDL_SCANCODE_F:
+                    gui_shortcut(gui_ShortcutFFWD);
+                    break;
+                case SDL_SCANCODE_L:
+                    gui_shortcut(gui_ShortcutLoadState);
+                    break;
+                case SDL_SCANCODE_S:
+                    gui_shortcut(gui_ShortcutSaveState);
+                    break;
+                case SDL_SCANCODE_M:
+                    gui_shortcut(gui_ShortcutShowMainMenu);
+                    break;
+            }
         }
     }
 }

--- a/platforms/desktop-shared/config.h
+++ b/platforms/desktop-shared/config.h
@@ -34,6 +34,14 @@
 
 static const int config_max_recent_roms = 10;
 
+#ifdef __APPLE__
+#define GUI_KEY "CMD"
+#elif _WIN64 || defined(_WIN32)
+#define GUI_KEY "WIN"
+#else
+#define GUI_KEY "META"
+#endif
+
 struct config_Emulator
 {
     bool paused = false;
@@ -96,6 +104,12 @@ struct config_Input
     int gamepad_y_axis;
 };
 
+struct config_Key
+{
+    SDL_Scancode scancode;
+    SDL_Keymod modifier;
+};
+
 struct config_Debug
 {
     bool debug = false;
@@ -105,6 +119,13 @@ struct config_Debug
     bool show_memory = true;
     bool show_video = false;
     int font_size = 0;
+
+    config_Key key_step_over;
+    config_Key key_step_frame;
+    config_Key key_continue;
+    config_Key key_run_to_cursor;
+    config_Key key_go_back;
+    config_Key key_toggle_breakpoint;
 };
 
 EXTERN mINI::INIFile* config_ini_file;

--- a/platforms/desktop-shared/gui.h
+++ b/platforms/desktop-shared/gui.h
@@ -65,6 +65,7 @@ EXTERN void gui_init(void);
 EXTERN void gui_destroy(void);
 EXTERN void gui_render(void);
 EXTERN void gui_shortcut(gui_ShortCutEvent event);
+EXTERN bool gui_process_input(int key, int mod);
 EXTERN void gui_load_rom(const char* path);
 
 #undef GUI_IMPORT


### PR DESCRIPTION
I've added a way to allow the debug keys to be redefined in the config.ini, because I wanted keys that matched Visual Studio (F10 to step, F5 to run, etc). This system could be generalised even more to allow remapping all gui shortcut keys. For starters I would probably get rid of the double mapping that I've made between `gui_shortcut_event_map` and `config_debug` and instead combine them so that there is an array of `gui_ShortCutEvents` in the config.

Let me know if this is something you're interested in. If so I can do some further work in this PR, or you can take it as-is if you like, or I can make further changes in another PR, or you can even just leave it if you're not interested. No problem either way!