### PR TITLE
Define `install` and `uninstall` targets

### DIFF
--- a/platforms/desktop-shared/Makefile.install
+++ b/platforms/desktop-shared/Makefile.install
@@ -1,0 +1,23 @@
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
+
+INSTALL ?= install
+INSTALL_PROGRAM ?= $(INSTALL)
+INSTALL_DATA ?= ${INSTALL} -m 644
+
+install: $(TARGET)
+	$(PRE_INSTALL)
+
+	$(NORMAL_INSTALL)
+	$(INSTALL_PROGRAM) -D $(TARGET) $(DESTDIR)$(bindir)/$(TARGET)
+
+	$(POST_INSTALL)
+
+uninstall:
+	$(PRE_UNINSTALL)
+
+	$(NORMAL_UNINSTALL)
+	rm $(DESTDIR)$(bindir)/$(TARGET)
+
+	$(POST_UNINSTALL)

--- a/platforms/linux/Makefile
+++ b/platforms/linux/Makefile
@@ -5,3 +5,4 @@ CPPFLAGS += `pkg-config --cflags gtk+-3.0`
 LDFLAGS += `pkg-config --libs gtk+-3.0`
 
 include ../desktop-shared/Makefile.common
+include ../desktop-shared/Makefile.install


### PR DESCRIPTION
The `make install` command is pretty useful for Linux machines to ensure that the built executable is available on the `PATH` directory, so this pull request aims to add the `install` and `uninstall` targets to support this.

I have attempted to adhere to the [Makefile Conventions](https://www.gnu.org/software/make/manual/make.html#Makefile-Conventions) as closely as possible (excluding those unnecessary for this project) which includes defaulting the installation to `/usr/local/gearsystem` and allowing this to be customisable with `DESTDIR` and `prefix` (e.g. `make install prefix="/app/bin"` to install the application to `/app/bin/gearsystem`).

The most notable use of this is to make automated packaging systems (such as flatpak-builder) much cleaner as they will only need to specify `make install` with appropriate arguments.

I have included these targets in a separate file—`Makefile.install`—as they are not applicable to every operating system; mostly just to Linux. I'm happy to add it to others if they are applicable, I'm just not that familiar with them.