### PR TITLE
Make use of containing ROM folder optional

### DIFF
--- a/platforms/desktop-shared/gui.cpp
+++ b/platforms/desktop-shared/gui.cpp
@@ -556,10 +556,17 @@ static void main_menu(void)
             
             ImGui::Separator();
 
+            static const char* const SAVE_FILES_LOCATION_OPTS[] = {
+                "Save Files In Custom Folder",
+#ifndef PREVENT_ROM_FOLDER_USAGE
+                "Save Files In ROM Folder",
+#endif
+            };
+            static constexpr int SAVE_FILES_LOCATION_OPTS_COUNT = sizeof(SAVE_FILES_LOCATION_OPTS) / sizeof(const char*);
             if (ImGui::BeginMenu("Save File Location"))
             {
                 ImGui::PushItemWidth(220.0f);
-                if (ImGui::Combo("##savefile_option", &config_emulator.savefiles_dir_option, "Save Files In Custom Folder\0Save Files In ROM Folder\0\0"))
+                if (ImGui::Combo("##savefile_option", &config_emulator.savefiles_dir_option, SAVE_FILES_LOCATION_OPTS, SAVE_FILES_LOCATION_OPTS_COUNT))
                 {
                     emu_savefiles_dir_option = config_emulator.savefiles_dir_option;
                 }
@@ -583,10 +590,17 @@ static void main_menu(void)
                 ImGui::EndMenu();
             }
 
+            static const char* const SAVE_STATES_LOCATION_OPTS[] = {
+                "Savestates In Custom Folder",
+#ifndef PREVENT_ROM_FOLDER_USAGE
+                "Savestates In ROM Folder",
+#endif
+            };
+            static constexpr int SAVE_STATES_LOCATION_OPTS_COUNT = sizeof(SAVE_STATES_LOCATION_OPTS) / sizeof(const char*);
             if (ImGui::BeginMenu("Save State Location"))
             {
                 ImGui::PushItemWidth(220.0f);
-                if (ImGui::Combo("##savestate_option", &config_emulator.savestates_dir_option, "Savestates In Custom Folder\0Savestates In ROM Folder\0\0"))
+                if (ImGui::Combo("##savestate_option", &config_emulator.savestates_dir_option, SAVE_STATES_LOCATION_OPTS, SAVE_STATES_LOCATION_OPTS_COUNT))
                 {
                     emu_savestates_dir_option = config_emulator.savestates_dir_option;
                 }


### PR DESCRIPTION
As alluded to in #95, it does not make much sense to provide an option to use a ROM's containing directory as a place to store resources if permission does not exist. This is most likely to happen when using APIs such as the [Portal API](https://docs.flatpak.org/en/latest/portal-api-reference.html) to gain access to individual files.

It is possible to detect if we are in a contained environment using environment variables, but I feel as though it may introduce unnecessary overhead for something we should likely know ahead of time during build.

I was originally going to have the combo removed altogether if there was only one option, but I decided against it for simplicity of this pull request. This is something I can implement, but I'm notorious for over-engineering, so I would rather push this now.

One area I wish to receive feedback on is the name of the preprocessor directive: `PREVENT_ROM_FOLDER_USAGE`. I'm not sure what convention is being used, given that those starting with `GS_` tend to be focused on the functionality itself rather than the GUI. I'm happy to change this directive's name if it is preferred.