### PR TITLE
docs: add OpenBSD build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ cd platforms/bsd
 gmake
 ```
 
+- OpenBSD
+
+``` shell
+doas pkg_add gmake sld3
+cd platforms/bsd
+LDFLAGS=-L/usr/X11R6/lib/ USE_CLANG=1 gmake
+```
+
 ### Libretro
 
 - Ubuntu / Debian / Raspberry Pi (Raspbian):


### PR DESCRIPTION
These are the instructions that I used to build the project in OpenBSD 7.8. Tested and verified working.