### PR TITLE
rpm: add libatomic build dependency

### DIFF
--- a/platforms/linux/rpm/gearsystem.spec
+++ b/platforms/linux/rpm/gearsystem.spec
@@ -13,6 +13,7 @@ BuildRequires:  make
 BuildRequires:  pkgconf-pkg-config
 BuildRequires:  mesa-libGL-devel
 BuildRequires:  SDL3-devel
+BuildRequires:  libatomic
 
 Requires:       mesa-libGL
 Requires:       SDL3


### PR DESCRIPTION
The Linux build explicitly links with `-latomic`, but the RPM spec does not declare `libatomic` as a build dependency.

Add `BuildRequires: libatomic` so RPM builds do not depend on it being pulled into the buildroot transitively.

This is required for clean RPM builds on RHEL 10. I maintain an RHEL 10 RPM package for Gearsystem in my RPM repository:

https://johngrimmreaper.github.io/rhel10-rpms/